### PR TITLE
Fix Vercel build platform mismatch

### DIFF
--- a/packages/tiles-playground/package.json
+++ b/packages/tiles-playground/package.json
@@ -24,7 +24,6 @@
     "@lexical/selection": "0.22.0",
     "@lexical/table": "0.22.0",
     "@lexical/utils": "0.22.0",
-    "@next/swc-darwin-arm64": "^14.2.28",
     "@types/dompurify": "^3.2.0",
     "@vercel/analytics": "^1.1.2",
     "@vercel/og": "^0.6.8",


### PR DESCRIPTION
## Summary
- remove macOS specific `@next/swc-darwin-arm64` dependency

This fixes a build failure on Vercel where Linux was trying to install a darwin-only package.

## Testing
- `npm install`
- `npm run build` *(fails: warnings about ESLint rules and `next build` errors)*

------
https://chatgpt.com/codex/tasks/task_e_687270e8c000832d95ad992792c4de9d